### PR TITLE
Hide contact info

### DIFF
--- a/app/controllers/initiatives_controller.rb
+++ b/app/controllers/initiatives_controller.rb
@@ -81,6 +81,7 @@ class InitiativesController < ApplicationController
   def find_or_create_group
     return new_group if initiative_params[:lead_group_id] == 'new'
 
+    initiative_params.delete('lead_group_attributes')
     select_group
   end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,7 +8,6 @@ class Group < ApplicationRecord
            foreign_key: 'lead_group_id',
            dependent: :destroy,
            inverse_of: :lead_group
-  validates :consent_to_share, acceptance: true
   accepts_nested_attributes_for :websites, allow_destroy: true
 
   def empty?

--- a/app/models/initiative.rb
+++ b/app/models/initiative.rb
@@ -27,6 +27,7 @@ class Initiative < ApplicationRecord
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def self.approved
     Initiative.all.map do |initiative|
       attributes = initiative.public_attributes
@@ -35,15 +36,18 @@ class Initiative < ApplicationRecord
         name: initiative.name,
         group: initiative.lead_group_name,
         contactName: attributes['contact_name'],
-        email: attributes['contact_email'],
+        contactEmail: attributes['contact_email'],
+        contactPhone: attributes['contact_phone'],
         summary: initiative.summary,
         images: image_urls(initiative.images),
+        websites: website_urls(initiative.websites),
         status: initiative.status_name,
         solutions: map_solutions(initiative),
         timestamp: initiative.updated_at
       }
     end
   end
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 
   def self.map_solutions(initiative)
@@ -59,6 +63,10 @@ class Initiative < ApplicationRecord
         only_path: true
       )
     end
+  end
+
+  def self.website_urls(websites)
+    websites.map(&:website)
   end
 
   def self.create_solution(mapped_solution)

--- a/app/models/initiative.rb
+++ b/app/models/initiative.rb
@@ -12,34 +12,45 @@ class Initiative < ApplicationRecord
   accepts_nested_attributes_for :solutions
   accepts_nested_attributes_for :lead_group
   accepts_nested_attributes_for :websites, allow_destroy: true
-  validates :consent_to_share, acceptance: true
 
   def set_default_location
     self.latitude ||= 51.742
     self.longitude ||= -2.222
   end
 
+  def public_attributes
+    if consent_to_share
+      attributes
+    else
+      attributes.except('contact_name', 'contact_email', 'contact_phone')
+    end
+  end
+
   # rubocop:disable Metrics/MethodLength
   def self.approved
     Initiative.all.map do |initiative|
+      attributes = initiative.public_attributes
       {
         location: initiative.location_attributes,
         name: initiative.name,
         group: initiative.lead_group_name,
-        contactName: initiative.contact_name,
-        email: initiative.contact_email,
+        contactName: attributes['contact_name'],
+        email: attributes['contact_email'],
         summary: initiative.summary,
         images: image_urls(initiative.images),
         status: initiative.status_name,
-        solutions:
-          initiative.solutions.map do |mapped_solution|
-            create_solution(mapped_solution)
-          end,
+        solutions: map_solutions(initiative),
         timestamp: initiative.updated_at
       }
     end
   end
   # rubocop:enable Metrics/MethodLength
+
+  def self.map_solutions(initiative)
+    initiative.solutions.map do |mapped_solution|
+      create_solution(mapped_solution)
+    end
+  end
 
   def self.image_urls(images)
     images.map do |image|

--- a/frontend/packs/initiatives_map.js
+++ b/frontend/packs/initiatives_map.js
@@ -27,6 +27,13 @@ function initialiseMap(initiatives) {
 
   mappedInitiatives = initiatives.map(initiative => {
     var marker = L.marker(initiative.location.latlng);
+    function item(title, value) {
+      if (value) {
+        return `<p>${title}: ${value}</p>`;
+      }
+
+      return "";
+    }
     const initiativeHtml = `<h1>${initiative.name}</h1>
           ${
             initiative.images.length
@@ -41,14 +48,17 @@ function initialiseMap(initiatives) {
               : ""
           }
           <p>${initiative.summary}</p>
-          <p>Group: ${initiative.group}</p>
-          <p>Contact Name: ${initiative.contactName}</p>
-          <p>Status: ${initiative.status}</p>
-          ${
-            initiative.website
-              ? `<p>Website: <a target="_blank" href="${initiative.website}">${initiative.website}</a></p>`
-              : ""
-          }
+          ${item("Group", initiative.group)}
+          ${item("Contact Name", initiative.contactName)}
+          ${item("Contact Email", initiative.contactEmail)}
+          ${item("Contact Phone", initiative.contactPhone)}
+          ${item("Status", initiative.status)}
+          ${initiative.websites
+            .map(
+              website =>
+                `<p>Website: <a target="_blank" href="${website}">${website}</a></p>`
+            )
+            .join("")}
           ${
             initiative.email
               ? `<p>Email: <a href="mailto:${initiative.email}">${initiative.email}</a></p>`

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -38,7 +38,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
            }
     end
 
-    websites = Group.last.websites
+    websites = Group.last.websites.sort_by(&:website)
     assert_equal 2, websites.size
     assert_equal 'http://one', websites[0].website
     assert_equal 'http://two', websites[1].website
@@ -71,7 +71,7 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
               ]
             }
           }
-    websites = Group.last.websites
+    websites = Group.last.websites.sort_by(&:website)
     assert_equal 2, websites.size
     assert_equal 'http://one', websites[0].website
     assert_equal 'http://two', websites[1].website

--- a/test/models/initiative_test.rb
+++ b/test/models/initiative_test.rb
@@ -54,11 +54,13 @@ class InitiativeTest < ActiveSupport::TestCase
         name: 'The Fruit Exchange',
         group: 'Down to Earth Stroud',
         contactName: 'No name',
-        email: 'info@downtoearthstroud.co.uk',
+        contactEmail: 'info@downtoearthstroud.co.uk',
+        contactPhone: '01453 700011',
         summary:
           'The Fruit Exchange connects food outlets with people who have surplus fruit or veg.',
         status: 'Operational',
         solutions: [],
+        websites: [],
         images: []
       }
     ]

--- a/test/models/initiative_test.rb
+++ b/test/models/initiative_test.rb
@@ -12,6 +12,36 @@ class InitiativeTest < ActiveSupport::TestCase
     assert_equal expected_initiative_attributes, initiatives
   end
 
+  test 'display contact info if consent given' do
+    initiative =
+      Initiative.new(
+        contact_name: 'so and so',
+        contact_email: 'so@test.com',
+        contact_phone: '1234',
+        consent_to_share: true
+      )
+
+    public_attributes = initiative.public_attributes
+    assert_equal 'so and so', public_attributes['contact_name']
+    assert_equal 'so@test.com', public_attributes['contact_email']
+    assert_equal '1234', public_attributes['contact_phone']
+  end
+
+  test 'do not display contact info if no consent' do
+    initiative =
+      Initiative.new(
+        contact_name: 'so and so',
+        contact_email: 'so@test.com',
+        contact_phone: '1234',
+        consent_to_share: false
+      )
+
+    public_attributes = initiative.public_attributes
+    assert_nil public_attributes['contact_name']
+    assert_nil public_attributes['contact_email']
+    assert_nil public_attributes['contact_phone']
+  end
+
   # rubocop:disable Metrics/MethodLength
   def expected_initiative_attributes
     [


### PR DESCRIPTION
When "consent to share" has not been checked don't share contact information on the website.