### PR TITLE
Improve base layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # README
+
+- `./nuke` - Nuke database
+- `rake import:taxonomy` Populate initiatives
+- `./run_tests` - Run tests

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,57 +15,59 @@
   <body>
     <div class="App">
       <header class="Header">
-        <div class="Header-main">
-          <%=link_to image_tag(asset_pack_path("media/images/logo.svg"), width: 100, class: 'Header-logo'), root_path %>
-          <div class="Header-content">
-            <nav class="Nav">
-              &nbsp;
-              <span class="Nav-main">
-                <%=link_to 'Add a project', new_initiative_path %>
-                <%=link_to 'Explore districts', districts_path %>
-              </span>
-              <span class="Nav-supplementary">
-                <%= link_to('About', about_path)%>
-                <%= link_to('Contact', contact_path)%>
+        <div class="Container">
+          <div class="Header-main">
+            <%=link_to image_tag(asset_pack_path("media/images/logo.svg"), width: 100, class: 'Header-logo'), root_path %>
+            <div class="Header-content">
+              <nav class="Nav">
+                &nbsp;
+                <span class="Nav-main">
+                  <%=link_to 'Add a project', new_initiative_path %>
+                  <%=link_to 'Explore districts', districts_path %>
+                </span>
+                <span class="Nav-supplementary">
+                  <%= link_to('About', about_path)%>
+                  <%= link_to('Contact', contact_path)%>
 
-                <a class="Nav-burger" onclick="document.querySelector('.Nav').classList.add('Nav-open')"><svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
-                    <g>
-                    <path fill="#ffffff" id="svg_1" d="m4,10l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2zm24,4l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2zm0,8l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2z"/>
-                    </g>
-                  </svg></a>
-              </span>
-              <nav class="Nav-flyover">
-                <a href="#" onclick="document.querySelector('.Nav').classList.remove('Nav-open');return false;">Close</a>
-                <hr />
-                <%=link_to 'Add a project', new_initiative_path %>
-                <%=link_to 'Explore districts', districts_path %>
-                <hr />
-                <%= link_to('About', about_path)%>
-                <%= link_to('Contact', contact_path)%>
-                <hr />
-                <% unless user_signed_in? %>
-                  <%= link_to 'Sign in', new_user_session_path %>
-                  <%= link_to 'Sign up', new_user_registration_path %>
-                <% end %>
-                <% if user_signed_in? %>
-                  <%= link_to('Initiatives', initiatives_path) %>
-                  <%= link_to('Groups', groups_path) %>
-                <% end %>
-                <% if user_is_admin? %>
+                  <a class="Nav-burger" onclick="document.querySelector('.Nav').classList.add('Nav-open')"><svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
+                      <g>
+                      <path fill="#ffffff" id="svg_1" d="m4,10l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2zm24,4l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2zm0,8l-24,0c-1.104,0 -2,0.896 -2,2s0.896,2 2,2l24,0c1.104,0 2,-0.896 2,-2s-0.896,-2 -2,-2z"/>
+                      </g>
+                    </svg></a>
+                </span>
+                <nav class="Nav-flyover">
+                  <a href="#" onclick="document.querySelector('.Nav').classList.remove('Nav-open');return false;">Close</a>
                   <hr />
-                  <%= link_to('Group Types', group_types_path) %>
-                  <%= link_to('Initiative Statuses', initiative_statuses_path) %>
-                <% end %>
-                <% if user_signed_in? %>
+                  <%=link_to 'Add a project', new_initiative_path %>
+                  <%=link_to 'Explore districts', districts_path %>
                   <hr />
-                  <%= link_to 'Sign out', destroy_user_session_path %>
-                <% end %>
-              </span>
+                  <%= link_to('About', about_path)%>
+                  <%= link_to('Contact', contact_path)%>
+                  <hr />
+                  <% unless user_signed_in? %>
+                    <%= link_to 'Sign in', new_user_session_path %>
+                    <%= link_to 'Sign up', new_user_registration_path %>
+                  <% end %>
+                  <% if user_signed_in? %>
+                    <%= link_to('Initiatives', initiatives_path) %>
+                    <%= link_to('Groups', groups_path) %>
+                  <% end %>
+                  <% if user_is_admin? %>
+                    <hr />
+                    <%= link_to('Group Types', group_types_path) %>
+                    <%= link_to('Initiative Statuses', initiative_statuses_path) %>
+                  <% end %>
+                  <% if user_signed_in? %>
+                    <hr />
+                    <%= link_to 'Sign out', destroy_user_session_path %>
+                  <% end %>
+                </span>
+                </nav>
               </nav>
-            </nav>
+            </div>
           </div>
+          <p class="Header-strapline">Connecting low carbon initiatives across Stroud District</p>
         </div>
-        <p class="Header-strapline">Connecting low carbon initiatives across Stroud District</p>
       </header>
 
       <% if notice || alert %>
@@ -78,19 +80,32 @@
           <% end %>
         </section>
       <% end %>
+
       <% content_class = yield :content_class %>
-      <main class="<%= (content_class.size > 0) ? content_class : 'Content'%> App-content">
-        <%= yield %>
+      <main class="App-content">
+        <% if content_class.size > 0 %>
+          <div class="<%= content_class %>">
+            <%= yield %>
+          </div>
+        <% else %>
+          <div class="Container">
+            <div class="Content">
+              <%= yield %>
+            </div>
+          </div>
+        <% end %>
       </main>
 
-      <section class="sponsors">
-        <h1>Sponsors</h1>
-        <div class="sponsors-logos">
-          <a class="sponsors-logo" href="https://featurist.co.uk" target="_blank"><img src="<%=asset_pack_path("media/logos/featurist.svg")%>"></a>
-        </div>
-      </section>
       <footer class="Footer">
-        <p>&copy; Carbon Map <time datetime="<%= Date.current.year %>"><%= Date.current.year %></time></p>
+        <div class="Container">
+          <section class="sponsors">
+            <h1>Sponsors</h1>
+            <div class="sponsors-logos">
+              <a class="sponsors-logo" href="https://featurist.co.uk" target="_blank"><img src="<%=asset_pack_path("media/logos/featurist.svg")%>"></a>
+            </div>
+          </section>
+          <p class="Footer-copyright">&copy; Carbon Map <time datetime="<%= Date.current.year %>"><%= Date.current.year %></time></p>
+        </div>
       </footer>
 
     </div>

--- a/frontend/styles/application.css
+++ b/frontend/styles/application.css
@@ -32,7 +32,14 @@
 }
 
 html {
+  box-sizing: border-box;
   height: 100%;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
 }
 
 body {

--- a/frontend/styles/application.css
+++ b/frontend/styles/application.css
@@ -9,6 +9,7 @@
 @import "./components/breadcrumb";
 @import "./components/button";
 @import "./components/collection-item";
+@import "./components/container";
 @import "./components/content";
 @import "./components/explore";
 @import "./components/header";

--- a/frontend/styles/components/container.css
+++ b/frontend/styles/components/container.css
@@ -1,0 +1,11 @@
+.Container {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (--bp-tablet-landscape) {
+
+  .Container {
+    max-width: 1080px;
+  }
+}

--- a/frontend/styles/components/content.css
+++ b/frontend/styles/components/content.css
@@ -1,17 +1,10 @@
 .Content {
   border: 1px solid lightgray;
+  margin-bottom: 30px;
+  margin-top: 30px;
   padding: 20px;
 }
 
 .Content p {
   margin-bottom: 15px;
-}
-
-@media (--bp-tablet) {
-
-  .Content {
-    display: block;
-    margin: 0 auto;
-    width: 75%;
-  }
 }

--- a/frontend/styles/components/explore.css
+++ b/frontend/styles/components/explore.css
@@ -15,7 +15,6 @@
   color: white;
   cursor: pointer;
   flex: 1;
-  margin-bottom: 2px;
   margin-right: 2px;
   padding: 3px;
   text-align: center;

--- a/frontend/styles/components/explore.css
+++ b/frontend/styles/components/explore.css
@@ -1,6 +1,6 @@
 .Explore {
   background-color: $snow;
-  height: 100%;
+  height: calc(100vh - 145px); /* Viewport height minus header height */
   position: relative;
 }
 

--- a/frontend/styles/components/explore.css
+++ b/frontend/styles/components/explore.css
@@ -13,6 +13,7 @@
   flex-wrap: wrap;
   position: absolute;
   width: 100%;
+  z-index: 2;
 }
 
 .Explore-navigation a {
@@ -51,6 +52,7 @@
   display: flex;
   height: 100%;
   overflow: hidden;
+  z-index: 1;
 }
 
 .Explore-initiative {

--- a/frontend/styles/components/explore.css
+++ b/frontend/styles/components/explore.css
@@ -1,10 +1,13 @@
 .Explore {
   background-color: $snow;
+  display: flex;
+  flex-direction: column;
   height: calc(100vh - 145px); /* Viewport height minus header height */
   position: relative;
 }
 
 .Explore-navigation {
+  background-color: #fff;
   bottom: 0;
   display: flex;
   flex-wrap: wrap;

--- a/frontend/styles/components/explore.css
+++ b/frontend/styles/components/explore.css
@@ -1,13 +1,15 @@
 .Explore {
   background-color: $snow;
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
+  height: 100%;
+  position: relative;
 }
 
 .Explore-navigation {
+  bottom: 0;
   display: flex;
   flex-wrap: wrap;
+  position: absolute;
+  width: 100%;
 }
 
 .Explore-navigation a {

--- a/frontend/styles/components/footer.css
+++ b/frontend/styles/components/footer.css
@@ -1,6 +1,10 @@
 .Footer {
+  background-color: #efefef;
   flex: none;
+}
+
+.Footer-copyright {
   font-size: 14px;
-  padding: 5px;
+  padding: 10px;
   text-align: center;
 }

--- a/frontend/styles/components/header.css
+++ b/frontend/styles/components/header.css
@@ -15,8 +15,7 @@
 }
 
 .Header-content {
-  display: inline-block;
-  flex: max-content;
+  flex-grow: 1;
   margin-left: 15px;
 }
 

--- a/frontend/styles/components/header.css
+++ b/frontend/styles/components/header.css
@@ -1,8 +1,8 @@
 .Header {
   border-bottom: 1px solid lightgray;
   flex: none;
-  margin-bottom: 30px;
   padding-bottom: 10px;
+  padding-top: 10px;
 }
 
 .Header-logo {

--- a/frontend/styles/components/nav.css
+++ b/frontend/styles/components/nav.css
@@ -14,7 +14,6 @@
   margin-right: 5px;
   text-align: center;
   text-decoration: none;
-  white-space: nowrap;
 }
 
 .Nav a::before {

--- a/frontend/styles/components/nav.css
+++ b/frontend/styles/components/nav.css
@@ -2,7 +2,7 @@
   background-color: #ff9700;
   color: #fff;
   display: flex;
-  height: 29px;
+  height: 43px;
   padding: 7px;
 }
 
@@ -14,6 +14,7 @@
   margin-right: 5px;
   text-align: center;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .Nav a::before {


### PR DESCRIPTION
- Add `.Container` for central column layout. Main content area on map pages remain full width
- Refactor map height to fill viewport exactly with filters along the bottom
- Fix full width header bar in Chrome
- Add `box-sizing: border-box` base CSS ([info](https://www.paulirish.com/2012/box-sizing-border-box-ftw/))
- Add some useful commands to the README

![screenshot](https://i.imgur.com/eYOQyzF.jpg)

![screenshot](https://i.imgur.com/IRi29hY.png)