### PR TITLE
show all initiatives as a list

### DIFF
--- a/app/controllers/initiatives_controller.rb
+++ b/app/controllers/initiatives_controller.rb
@@ -4,10 +4,15 @@
 class InitiativesController < ApplicationController
   before_action :set_initiative, only: %i[edit update]
   before_action :set_edit_data, only: %i[edit new create update]
-  skip_before_action :authenticate_user!, only: %i[show]
+  skip_before_action :authenticate_user!, only: %i[index show]
+  helper_method :can_edit?
+
+  def can_edit?(initiative)
+    initiative.owner == current_user
+  end
 
   def index
-    @initiatives = current_user.all_initiatives
+    @initiatives = Initiative.all
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,9 +14,5 @@ class User < ApplicationRecord
   has_many :initiatives, foreign_key: 'owner_id', inverse_of: :owner, dependent: :nullify
   has_many :groups_initiatives, through: :groups, source: :initiatives
 
-  def all_initiatives
-    (initiatives + groups_initiatives).uniq
-  end
-
   attribute :role, :string, default: 'consumer'
 end

--- a/app/views/initiatives/index.html.erb
+++ b/app/views/initiatives/index.html.erb
@@ -18,17 +18,23 @@
       <th>Name</th>
       <th>Location</th>
       <th>Status</th>
+      <th>Last Updated</th>
       <th></th>
     </tr>
   </thead>
 
   <tbody>
     <% @initiatives.each do |initiative| %>
-      <tr>
-        <td><%= initiative.name %></td>
+      <tr class="Initiative">
+        <td><%= link_to initiative.name, initiative_path(initiative) %></td>
         <td><%= initiative.location %></td>
         <td><%= initiative.status_name %></td>
-        <td><%= link_to 'Edit', edit_initiative_path(initiative), "data-turbolinks": false, class: 'Button Button--success' %></td>
+        <td><%= initiative.updated_at.strftime '%d/%m/%y %H:%M' %></td>
+        <% if can_edit? initiative %>
+          <td><%= link_to 'Edit', edit_initiative_path(initiative), "data-turbolinks": false, class: 'Button Button--success', data: {content: 'edit-initiative'} %></td>
+        <% else %>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@ set_meta_tags og: {
                     <a href="#" onclick="document.querySelector('.Nav').classList.remove('Nav-open');return false;">Close</a>
                     <hr />
                     <%= link_to 'Add a project', new_initiative_path %>
+                    <%= link_to 'Initiatives', initiatives_path %>
                     <hr />
                     <%= link_to('About', about_path)%>
                     <%= link_to('Contact', contact_path)%>
@@ -70,6 +71,7 @@ set_meta_tags og: {
                 &nbsp;
                 <span class="Nav-main">
                   <%=link_to inline_icon('circle') + '<span>Add a project</span>'.html_safe, new_initiative_path %>
+                  <%=link_to inline_icon('circle') + '<span>Initiatives</span>'.html_safe, initiatives_path %>
                 </span>
                 <span class="Nav-supplementary">
                   <%= link_to('About', about_path)%>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2020_01_18_113424) do
     t.string "administrative_notes"
     t.boolean "carbon_saving_anticipated", default: false, null: false
     t.boolean "carbon_saving_quantified", default: false, null: false
+    t.boolean "draft", default: false, null: false
     t.bigint "owner_id"
     t.index ["lead_group_id"], name: "index_initiatives_on_lead_group_id"
     t.index ["owner_id"], name: "index_initiatives_on_owner_id"

--- a/test/controllers/initiatives_controller_test.rb
+++ b/test/controllers/initiatives_controller_test.rb
@@ -13,9 +13,18 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
     Rack::Test::UploadedFile.new('test/fixtures/files/header.jpg', 'image/jpeg')
   end
 
-  test 'should get index' do
+  test 'should get index when anonymous' do
+    get initiatives_url
+    assert_select '.Initiative', count: Initiative.all.size
+    assert_select '*[data-content=edit-initiative]', count: 0
+    assert_response :success
+  end
+
+  test 'should get index when signed in' do
     sign_in_as :georgie
     get initiatives_url
+    assert_select '.Initiative', count: Initiative.all.size
+    assert_select '*[data-content=edit-initiative]', count: Initiative.all.size
     assert_response :success
   end
 

--- a/test/system/initiatives_test.rb
+++ b/test/system/initiatives_test.rb
@@ -5,7 +5,6 @@ require 'application_system_test_case'
 class InitiativesTest < ApplicationSystemTestCase
   test 'visiting the index' do
     visit initiatives_url
-    sign_in_as :georgie
     assert_selector 'h1', text: 'Initiatives'
   end
 


### PR DESCRIPTION
Show all the initiatives in a list.

When not logged in don't show any actions:
![image](https://user-images.githubusercontent.com/144922/77584411-a5189900-6eda-11ea-8f5b-240d170664ee.png)

When logged in show an edit link for the initiatives the user can edit
![image](https://user-images.githubusercontent.com/144922/77584342-887c6100-6eda-11ea-94fb-d05416a14bcb.png)
