### PR TITLE
Add publication_status to initiative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-debug.log*
 
 # these images are copied in at install time
 /public/leaflet
+*.dump
+.envrc

--- a/app/controllers/districts_controller.rb
+++ b/app/controllers/districts_controller.rb
@@ -6,7 +6,7 @@ class DistrictsController < ApplicationController
   def show
     @district = District.find(params['id'])
     initiatives =
-      Initiative.includes(parish: %i[ward]).where(
+      Initiative.published.includes(parish: %i[ward]).where(
         parishes: { wards: { district_id: @district.id } }
       )
     @map_data = MapData.new(initiatives)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,7 @@ class HomeController < ApplicationController
 
   def index
     @initiatives_json = Initiative.approved.to_json
-    initiatives = Initiative.all
+    initiatives = Initiative.published
     @map_data = MapData.new(initiatives)
     @sectors = Sector.all
     @districts = District.all

--- a/app/controllers/initiatives_controller.rb
+++ b/app/controllers/initiatives_controller.rb
@@ -53,6 +53,11 @@ class InitiativesController < ApplicationController
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def update
+    if @initiative.publication_status == 'archived'
+      redirect_to initiatives_path, notice: "'#{@initiative.name}' has been archived and cannot be edited"
+      return
+    end
+
     clear_solutions_and_themes && create_proposed_solutions
     images = initiative_params.delete 'images'
     find_or_create_group

--- a/app/controllers/initiatives_controller.rb
+++ b/app/controllers/initiatives_controller.rb
@@ -38,12 +38,11 @@ class InitiativesController < ApplicationController
   # rubocop:disable Metrics/MethodLength
   def create
     create_proposed_solutions
-    @initiative = Initiative.new(initiative_params)
-    @initiative.owner = current_user
+    @initiative = Initiative.new(initiative_params.merge(owner: current_user))
     find_or_create_group
     @initiative.update_location_from_postcode
 
-    if @initiative.save
+    if @initiative.save(validate: @initiative.publication_status != 'draft')
       redirect_to edit_initiative_path(@initiative),
                   notice: 'Initiative was successfully created.'
     else
@@ -52,7 +51,7 @@ class InitiativesController < ApplicationController
   end
   # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def update
     clear_solutions_and_themes && create_proposed_solutions
     images = initiative_params.delete 'images'
@@ -60,7 +59,7 @@ class InitiativesController < ApplicationController
     @initiative.assign_attributes initiative_params
     @initiative.update_location_from_postcode
 
-    if @initiative.save
+    if @initiative.save(validate: @initiative.publication_status != 'draft')
       @initiative.images.attach images if images
       redirect_to edit_initiative_path(@initiative),
                   notice: 'Initiative was successfully updated.'
@@ -68,7 +67,7 @@ class InitiativesController < ApplicationController
       render :edit
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   private
 

--- a/app/controllers/initiatives_controller.rb
+++ b/app/controllers/initiatives_controller.rb
@@ -12,7 +12,8 @@ class InitiativesController < ApplicationController
   end
 
   def index
-    @initiatives = Initiative.all
+    current_users_initiatives = current_user&.initiatives || []
+    @initiatives = (Initiative.published + current_users_initiatives).uniq.sort_by(&:name)
   end
 
   def show
@@ -182,6 +183,7 @@ class InitiativesController < ApplicationController
         :contact_phone,
         :partner_groups_role,
         :status_id,
+        :publication_status,
         :consent_to_share,
         :related_initiatives,
         :administrative_notes,

--- a/app/controllers/parishes_controller.rb
+++ b/app/controllers/parishes_controller.rb
@@ -7,7 +7,7 @@ class ParishesController < ApplicationController
     @parish = Parish.find(params['id'])
     @ward = @parish.ward
     @district = @ward.district
-    initiatives = Initiative.where(parish_id: @parish.id)
+    initiatives = Initiative.published.where(parish_id: @parish.id)
     @map_data = MapData.new(initiatives)
     @sectors = Sector.all
   end

--- a/app/controllers/wards_controller.rb
+++ b/app/controllers/wards_controller.rb
@@ -6,7 +6,7 @@ class WardsController < ApplicationController
   def show
     @ward = Ward.find(params['id'])
     initiatives =
-      Initiative.includes(parish: %i[ward]).where(
+      Initiative.published.includes(parish: %i[ward]).where(
         parishes: { ward_id: @ward.id }
       )
     @district = @ward.district

--- a/app/helpers/initiatives_helper.rb
+++ b/app/helpers/initiatives_helper.rb
@@ -18,4 +18,12 @@ module InitiativesHelper
 
     solution_map.to_json
   end
+
+  def publication_statuses
+    statuses = Initiative.publication_statuses.to_h
+    statuses.reject! { |status| %w[rejected archived].include?(status) } unless user_is_admin?
+    statuses.map do |key, value|
+      [value.titlecase, key]
+    end
+  end
 end

--- a/app/models/initiative.rb
+++ b/app/models/initiative.rb
@@ -68,6 +68,8 @@ class Initiative < ApplicationRecord
   end
 
   def fetch_location
+    return unless postcode
+
     postcodes_url = "https://api.postcodes.io/postcodes/#{postcode.delete(' ')}"
     json_response = Net::HTTP.get(URI(postcodes_url))
     JSON.parse(json_response)['result']

--- a/app/models/initiative.rb
+++ b/app/models/initiative.rb
@@ -96,7 +96,7 @@ class Initiative < ApplicationRecord
   end
 
   def self.approved
-    Initiative.all.map(&:to_public_initiative)
+    Initiative.published.map(&:to_public_initiative)
   end
 
   def to_public_initiative

--- a/app/views/initiatives/_form.html.erb
+++ b/app/views/initiatives/_form.html.erb
@@ -170,9 +170,11 @@
     <%= f.text_area :administrative_notes %>
   <% end %>
 
-  <%= f.form_field :publication_status, required: true do %>
-    <%= f.label :publication_status, 'Publication Status' %>
-    <%= f.select :publication_status, publication_statuses %>
+  <% if publication_statuses.map {|s| s[1]}.include?(initiative.publication_status) %>
+    <%= f.form_field :publication_status, required: true do %>
+      <%= f.label :publication_status, 'Publication Status' %>
+      <%= f.select :publication_status, publication_statuses %>
+    <% end %>
   <% end %>
 
   <div class="FormField-actions">

--- a/app/views/initiatives/_form.html.erb
+++ b/app/views/initiatives/_form.html.erb
@@ -170,6 +170,11 @@
     <%= f.text_area :administrative_notes %>
   <% end %>
 
+  <%= f.form_field :publication_status, required: true do %>
+    <%= f.label :publication_status, 'Publication Status' %>
+    <%= f.select :publication_status, publication_statuses %>
+  <% end %>
+
   <div class="FormField-actions">
     <%= f.submit class: 'Button Button--success Button--large' %>
   </div>

--- a/app/views/initiatives/index.html.erb
+++ b/app/views/initiatives/index.html.erb
@@ -25,7 +25,7 @@
 
   <tbody>
     <% @initiatives.each do |initiative| %>
-      <tr class="Initiative">
+      <tr class="Initiative Initiative-<%=initiative.publication_status%>">
         <td><%= link_to initiative.name, initiative_path(initiative) %></td>
         <td><%= initiative.location %></td>
         <td><%= initiative.status_name %></td>

--- a/app/views/parishes/show.html.erb
+++ b/app/views/parishes/show.html.erb
@@ -14,12 +14,12 @@
 ] do %>
   <div class="sidebar-pane Explore-navigation" id="initiatives">
     <h1 class="sidebar-header">Initiatives</h1>
-  <% @parish.initiatives.each do |initiative| %>
-    <%=link_to initiative.name, initiative%>
-    <% unless @parish.initiatives.last == initiative %>
-      <hr />
-    <% end %>
+    <% initiatives = @parish.initiatives.published %>
+    <% initiatives.each do |initiative| %>
+      <%=link_to initiative.name, initiative%>
+      <% unless initiatives.last == initiative %>
+        <hr />
+      <% end %>
   <% end %>
   </div>
 <% end %>
-

--- a/config/rails_best_practices.yml
+++ b/config/rails_best_practices.yml
@@ -13,7 +13,7 @@ MoveCodeIntoControllerCheck: {}
 MoveCodeIntoHelperCheck: { array_count: 3 }
 MoveCodeIntoModelCheck: { use_count: 2 }
 MoveFinderToNamedScopeCheck: {}
-MoveModelLogicIntoModelCheck: { use_count: 4 }
+MoveModelLogicIntoModelCheck: { use_count: 6 }
 NeedlessDeepNestingCheck: { nested_count: 2 }
 NotRescueExceptionCheck: {}
 NotUseDefaultRouteCheck: {}

--- a/db/migrate/20200616193415_add_publication_status_to_initiative.rb
+++ b/db/migrate/20200616193415_add_publication_status_to_initiative.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddPublicationStatusToInitiative < ActiveRecord::Migration[6.0]
+  def change
+    add_column :initiatives, :publication_status, :string
+    add_index :initiatives, :publication_status
+
+    reversible do |dir|
+      dir.up do
+        ActiveRecord::Base.connection.execute("update initiatives set publication_status = 'published'")
+      end
+    end
+  end
+end

--- a/db/migrate/20200616193415_add_publication_status_to_initiative.rb
+++ b/db/migrate/20200616193415_add_publication_status_to_initiative.rb
@@ -10,5 +10,8 @@ class AddPublicationStatusToInitiative < ActiveRecord::Migration[6.0]
         ActiveRecord::Base.connection.execute("update initiatives set publication_status = 'published'")
       end
     end
+
+    change_column_null :initiatives, :lead_group_id, true
+    change_column_null :initiatives, :status_id, true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,12 +127,12 @@ ActiveRecord::Schema.define(version: 2020_06_16_193415) do
     t.string "name"
     t.string "description_further_information"
     t.integer "carbon_saving_amount"
-    t.bigint "lead_group_id", null: false
+    t.bigint "lead_group_id"
     t.string "contact_name"
     t.string "contact_email"
     t.string "contact_phone"
     t.string "partner_groups_role"
-    t.bigint "status_id", null: false
+    t.bigint "status_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.float "latitude"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -146,7 +146,6 @@ ActiveRecord::Schema.define(version: 2020_06_16_193415) do
     t.string "administrative_notes"
     t.boolean "carbon_saving_anticipated", default: false, null: false
     t.boolean "carbon_saving_quantified", default: false, null: false
-    t.boolean "draft", default: false, null: false
     t.bigint "owner_id"
     t.string "publication_status"
     t.index ["lead_group_id"], name: "index_initiatives_on_lead_group_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_18_113424) do
+ActiveRecord::Schema.define(version: 2020_06_16_193415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,9 +148,11 @@ ActiveRecord::Schema.define(version: 2020_01_18_113424) do
     t.boolean "carbon_saving_quantified", default: false, null: false
     t.boolean "draft", default: false, null: false
     t.bigint "owner_id"
+    t.string "publication_status"
     t.index ["lead_group_id"], name: "index_initiatives_on_lead_group_id"
     t.index ["owner_id"], name: "index_initiatives_on_owner_id"
     t.index ["parish_id"], name: "index_initiatives_on_parish_id"
+    t.index ["publication_status"], name: "index_initiatives_on_publication_status"
     t.index ["status_id"], name: "index_initiatives_on_status_id"
   end
 

--- a/frontend/packs/initiative_solution_picker.js
+++ b/frontend/packs/initiative_solution_picker.js
@@ -97,8 +97,8 @@ class SolutionPicker {
                 class="AddInitiativeResults-item"
                 onclick={() => this.addSolution(solution)}
               >
-                {solution.sector} > {solution.theme} > {solution.class} >{" "}
-                {solution.solution}
+                {solution.sector} &gt; {solution.theme} &gt; {solution.class}{" "}
+                &gt; {solution.solution}
               </li>
             );
           })}
@@ -125,7 +125,7 @@ class SolutionPicker {
     function renderSector() {
       if (self.navigation.sector) {
         return [
-          <span>&nbsp;>&nbsp;</span>,
+          <span>&nbsp;&gt;&nbsp;</span>,
           <span
             onclick={() => self.navigate({ sector: self.navigation.sector })}
           >
@@ -137,7 +137,7 @@ class SolutionPicker {
     function renderTheme() {
       if (self.navigation.theme) {
         return [
-          <span>&nbsp;>&nbsp;</span>,
+          <span>&nbsp;gt;&nbsp;</span>,
           <span onclick={() => self.navigate({ theme: self.navigation.theme })}>
             {self.navigation.theme.name}
           </span>
@@ -147,7 +147,7 @@ class SolutionPicker {
     function renderSolutionClass() {
       if (self.navigation.solutionClass) {
         return [
-          <span>&nbsp;>&nbsp;</span>,
+          <span>&nbsp;&gt;&nbsp;</span>,
           <span
             onclick={() =>
               self.navigate({ solutionClass: self.navigation.solutionClass })
@@ -369,7 +369,7 @@ class SolutionPicker {
             return (
               <li class="Solution-item">
                 <span class="Solution-itemDescription">
-                  {theme.sector} > {theme.name}
+                  {theme.sector} &gt; {theme.name}
                 </span>
                 <img
                   src={closeCircle}
@@ -388,8 +388,8 @@ class SolutionPicker {
             return (
               <li class="Solution-item">
                 <span class="Solution-itemDescription">
-                  {solution.sector} > {solution.theme} > {solution.class} >{" "}
-                  {solution.solution}
+                  {solution.sector} &gt; {solution.theme} &gt; {solution.class}{" "}
+                  &gt; {solution.solution}
                 </span>
                 <img
                   src={closeCircle}

--- a/frontend/styles/components/initiative.css
+++ b/frontend/styles/components/initiative.css
@@ -7,3 +7,7 @@
 .Initiative-website {
   text-decoration: none;
 }
+
+.Initiative-rejected {
+  opacity: 0.5;
+}

--- a/lib/tasks/db_update.rake
+++ b/lib/tasks/db_update.rake
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 namespace :db_update do
   task :production do
     app_name = ENV['CARBON_MAP_APP_NAME']

--- a/lib/tasks/db_update.rake
+++ b/lib/tasks/db_update.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+namespace :db_update do
+  task :production do
+    app_name = ENV['CARBON_MAP_APP_NAME']
+    unless app_name
+      $stdout.puts 'Heroku app name?'
+      app_name = $stdin.gets.strip.downcase
+    end
+
+    sh "heroku pg:backups:download -a #{app_name}"
+
+    sh 'dropdb carbon_map_development --if-exists'
+    sh 'createdb carbon_map_development'
+
+    begin
+      sh 'PGGSSENCMODE=disable pg_restore --verbose --clean --no-acl --no-owner' \
+        ' -d carbon_map_development latest.dump'
+    rescue RuntimeError => e
+      puts '----------------------------------------------------'
+      puts 'IGNORING ERRORS! by pg_restore (Double check the above errors are OK!)'
+      puts e.message
+      puts '----------------------------------------------------'
+    end
+
+    sh 'rails db:migrate'
+  end
+end

--- a/test/controllers/initiatives_controller_test.rb
+++ b/test/controllers/initiatives_controller_test.rb
@@ -65,6 +65,16 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_initiative_path(Initiative.last)
   end
 
+  test 'archived initiative cannot be edited' do
+    @initiative.update!(publication_status: 'archived')
+
+    sign_in_as :georgie
+    patch initiative_url(@initiative),
+          params: update_params(@initiative)
+
+    assert_redirected_to initiatives_path
+  end
+
   test 'create initiative and lead group' do
     sign_in_as :georgie
     lead_group = {

--- a/test/controllers/initiatives_controller_test.rb
+++ b/test/controllers/initiatives_controller_test.rb
@@ -54,6 +54,17 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to edit_initiative_path(Initiative.last)
   end
 
+  test 'create draft initiative' do
+    sign_in_as :georgie
+    assert_difference('Initiative.count') do
+      post initiatives_url, params: { initiative: { name: 'draft init', publication_status: 'draft' } }
+    end
+    initiative = Initiative.last
+    assert_equal 'draft init', initiative.name
+
+    assert_redirected_to edit_initiative_path(Initiative.last)
+  end
+
   test 'create initiative and lead group' do
     sign_in_as :georgie
     lead_group = {

--- a/test/controllers/initiatives_controller_test.rb
+++ b/test/controllers/initiatives_controller_test.rb
@@ -75,6 +75,18 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to initiatives_path
   end
 
+  test 'pubication status ignored on rejected initiative' do
+    @initiative.update!(publication_status: 'rejected')
+
+    sign_in_as :georgie
+    VCR.use_cassette('valid_postcode') do
+      patch initiative_url(@initiative),
+            params: update_params(@initiative, publication_status: 'published')
+    end
+
+    assert_equal 'rejected', @initiative.reload.publication_status
+  end
+
   test 'create initiative and lead group' do
     sign_in_as :georgie
     lead_group = {
@@ -264,7 +276,8 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
   end
 
   def update_params(initiative, images: nil, solutions: nil,
-                    carbon_saving_anticipated: false, carbon_saving_quantified: false, carbon_saving_amount: nil)
+                    carbon_saving_anticipated: false, carbon_saving_quantified: false,
+                    carbon_saving_amount: nil, publication_status: nil)
     solutions ||= default_solutions
     {
       initiative: {
@@ -284,6 +297,7 @@ class InitiativesControllerTest < ActionDispatch::IntegrationTest
         description_how: initiative.description_how,
         images: images,
         consent_to_share: true,
+        publication_status: publication_status || initiative.publication_status,
         solutions_attributes: solutions,
         administrative_notes: 'updated notes',
         websites_attributes: [

--- a/test/fixtures/initiatives.yml
+++ b/test/fixtures/initiatives.yml
@@ -16,6 +16,7 @@ fruit_exchange:
   contact_email: info@downtoearthstroud.co.uk
   status: operational
   consent_to_share: true
+  publication_status: published
 
 brians_initiative:
   owner: brian
@@ -33,3 +34,4 @@ brians_initiative:
   contact_email: info@example.com
   status: operational
   consent_to_share: true
+  publication_status: published

--- a/test/models/initiative_test.rb
+++ b/test/models/initiative_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 
 class InitiativeTest < ActiveSupport::TestCase
+  test 'new initiative defaults to draft' do
+    assert_equal 'draft', Initiative.new.publication_status
+  end
+
   test 'approved json' do
     initiatives =
       Initiative.approved.map do |initiative|


### PR DESCRIPTION
Add a publication status so that initiatives can be taken offline
Users who are not administrators have draft/published options
![image](https://user-images.githubusercontent.com/144922/84826889-8dedd100-b01b-11ea-856c-9a0ba33d1d22.png)

Admin users have all options
![image](https://user-images.githubusercontent.com/144922/84826960-a827af00-b01b-11ea-910f-f583f2326dd6.png)

Fixes #86